### PR TITLE
Make example adhere to schema

### DIFF
--- a/setu-planning/v1.0/PlanningAssignment/PlanningAssignment_Example_v1.0.json
+++ b/setu-planning/v1.0/PlanningAssignment/PlanningAssignment_Example_v1.0.json
@@ -61,13 +61,13 @@
         "schemeAgencyId": "Customer"
       },
       "planningPeriod": "Monday",
-      "startTime": "07:00:00",
-      "endTime": "16:00:00",
+      "startTime": "07:00:00Z",
+      "endTime": "16:00:00Z",
       "breaks": [
         {
           "paidOrUnpaid": "Paid",
-          "startTime": "11:30:00",
-          "endTime": "12:00:00"
+          "startTime": "11:30:00Z",
+          "endTime": "12:00:00Z"
         }
       ]
     }


### PR DESCRIPTION
According to
https://github.com/setu-standards/xml-specifications/blob/f6f12c9c4ab7a4d0c2f6e7e25c0652d593f5f494/setu-planning/v1.0/PlanningAssignment/PlanningAssignment_v1.0.yml#L500 times should be formatted according to the 'time' format. This is defined in
https://datatracker.ietf.org/doc/html/draft-handrews-json-schema-validation-00#section-7.3.1 and states it should adhere to section 5.6 of RFC3339, defined in https://datatracker.ietf.org/doc/html/rfc3339#section-5.6

Here the production rule for 'full-time' states it is produced by having a 'partial time' followed by a 'time-offset'.

The production rule for 'time-offset' is:

```
time-offset     = "Z" / time-numoffset
```

with:

```
time-numoffset  = ("+" / "-") time-hour ":" time-minute
```

This means the time format expects the time to be either followed by a 'Z', or an positive or negative time offset.

The times in the example PlanningAssignement have neither, resulting in a failed validation when validated against the schema in https://github.com/setu-standards/xml-specifications/blob/main/setu-planning/v1.0/PlanningAssignment/PlanningAssignment_v1.0.yml

This PR simply appends a 'Z' to all times to make sure the example message can successfully be validated against the provided schema.